### PR TITLE
Add Homebridge 2.x compatibility

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -21,6 +21,8 @@ I do not have a lot of time to maintain this repo either but will do my best to 
 
 Control your supported Tuya accessories locally in HomeKit
 
+This plugin is compatible with Homebridge v1.3 and v2.0.
+
 - [Supported Device Types](#supported-device-types)
 - [Installation Instructions](#installation-instructions)
 - [Configuration](#configuration)

--- a/index.js
+++ b/index.js
@@ -54,13 +54,17 @@ const CLASS_DEF = {
 
 let Characteristic, PlatformAccessory, Service, Categories, AdaptiveLightingController, UUID;
 
-module.exports = function(homebridge) {
+module.exports = function(api) {
     ({
         platformAccessory: PlatformAccessory,
         hap: {Characteristic, Service, AdaptiveLightingController, Accessory: {Categories}, uuid: UUID}
-    } = homebridge);
+    } = api);
 
-    homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, TuyaPlatformLocal, true);
+    if (api.registerPlatform.length > 2) {
+        api.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, TuyaPlatformLocal, true);
+    } else {
+        api.registerPlatform(PLATFORM_NAME, TuyaPlatformLocal);
+    }
 };
 
 class TuyaPlatformLocal {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-tuya",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-tuya",
-      "version": "3.0.0-beta.3",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-tuya-platform-local",
   "displayName": "Homebridge Tuya Local",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "🏠 Unofficial Homebridge plugin enabling local control of Tuya smart devices",
   "main": "index.js",
   "scripts": {
@@ -38,7 +38,7 @@
     "tuya"
   ],
   "engines": {
-    "homebridge": ">=0.4.0",
+    "homebridge": ">=1.3.0",
     "node": ">=14.17.0"
   }
 }


### PR DESCRIPTION
## Summary
- support new Homebridge `registerPlatform` API
- document compatibility with Homebridge 2.x
- bump package version to 3.0.3
- update engines field

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875c7b99344832fa18adca3e0c6e968