### PR TITLE
Fix package metadata and rename package

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -5,15 +5,15 @@ Since the original repo is no longer maintained, I have forked it to correct sev
 I do not have a lot of time to maintain this repo either but will do my best to merge PRs and fix issues.
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/hmenzagh/homebridge-tuya-platform-local/main/assets/Tuya-Plugin-Branding.png" height="100"><br>
+    <img src="https://raw.githubusercontent.com/sapireli/homebridge-tuya-platform-local2/main/assets/Tuya-Plugin-Branding.png" height="100"><br>
 </p>
 
 <span align="center">
 
-# Homebridge-Tuya-Platform-Local
+# Homebridge-Tuya-Platform-Local2
 
-[![npm](https://img.shields.io/npm/v/homebridge-tuya-platform-local.svg)](https://www.npmjs.com/package/homebridge-tuya-platform-local)
-[![npm](https://img.shields.io/npm/dt/homebridge-tuya-platform-local.svg)](https://www.npmjs.com/package/homebridge-tuya-platform-local)
+[![npm](https://img.shields.io/npm/v/homebridge-tuya-platform-local2.svg)](https://www.npmjs.com/package/homebridge-tuya-platform-local2)
+[![npm](https://img.shields.io/npm/dt/homebridge-tuya-platform-local2.svg)](https://www.npmjs.com/package/homebridge-tuya-platform-local2)
 
 <!-- [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins) -->
 
@@ -36,23 +36,23 @@ This plugin is compatible with Homebridge v1.3 and v2.0.
 
 > Click the number next to your device to find the possible DataPoint "DP" values, then add as needed to your config.
 
-- Air Conditioner<sup>[1](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types#air-conditioners)</sup>
+- Air Conditioner<sup>[1](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types#air-conditioners)</sup>
 - Air Purifiers<sup>[2]()</sup>
-- Convectors<sup>[3](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types#heat-convectors)</sup>
-- Dehumidifers<sup>[4](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types)</sup>
-- Dimmers<sup>[5](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types#simple-dimmers)</sup>
-- Fan<sup>[6](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types)</sup>
-- Fan v2<sup>[7](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types)</sup>
-- Garages<sup>[8](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types#garage-doors)</sup>
-- Heaters<sup>[9](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types)</sup>
+- Convectors<sup>[3](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types#heat-convectors)</sup>
+- Dehumidifers<sup>[4](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types)</sup>
+- Dimmers<sup>[5](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types#simple-dimmers)</sup>
+- Fan<sup>[6](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types)</sup>
+- Fan v2<sup>[7](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types)</sup>
+- Garages<sup>[8](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types#garage-doors)</sup>
+- Heaters<sup>[9](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types)</sup>
 - Lights
-  - On/Off<sup>[10](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types)</sup>
-  - Brightness<sup>[11](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types#tunable-white-light-bulbs)</sup>
-  - Color<sup>[12](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types#white-and-color-light-bulbs)</sup> (Hue, Saturation, Adaptive Lighting)
-- Oil Diffusers<sup>[13](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types)</sup>
-- Outlets<sup>[14](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types#outlets)</sup>
+  - On/Off<sup>[10](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types)</sup>
+  - Brightness<sup>[11](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types#tunable-white-light-bulbs)</sup>
+  - Color<sup>[12](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types#white-and-color-light-bulbs)</sup> (Hue, Saturation, Adaptive Lighting)
+- Oil Diffusers<sup>[13](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types)</sup>
+- Outlets<sup>[14](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types#outlets)</sup>
 - Presence Sensor (ZY-M100)
-- Switches<sup>[15](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types)</sup>
+- Switches<sup>[15](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types)</sup>
 
 Note: Motion, and other sensor types don't behave well with responce requests, so they will not be added.
 
@@ -60,12 +60,12 @@ Note: Motion, and other sensor types don't behave well with responce requests, s
 
 #### Option 1: Install via Homebridge Config UI X:
 
-Search for "Tuya" in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x) and install `homebridge-tuya`.
+Search for "Tuya" in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x) and install `homebridge-tuya-platform-local2`.
 
 #### Option 2: Manually Install:
 
 ```
-sudo npm install -g homebridge-tuya
+sudo npm install -g homebridge-tuya-platform-local2
 ```
 
 ## Configuration

--- a/config-example.MD
+++ b/config-example.MD
@@ -6,7 +6,7 @@
 
 
 ## Configurations
-The configuration parameters to enable your devices would need to be added to `platforms` section of the Homebridge configuration file. Examples of device configs can be found on the [Supported Device Types](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types) page. Check out the [Common Problems](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Common-Problems) page for solutions or raise an issue if you face problems.
+The configuration parameters to enable your devices would need to be added to `platforms` section of the Homebridge configuration file. Examples of device configs can be found on the [Supported Device Types](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types) page. Check out the [Common Problems](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Common-Problems) page for solutions or raise an issue if you face problems.
 ```json5
 {
     ...
@@ -35,9 +35,9 @@ The configuration parameters to enable your devices would need to be added to `p
 ```
 #### Parameters
 * `name` (required) is anything you'd like to use to identify this device. You can always change the name from within the Home app.
-* `type` (required) is a case-insensitive identifier that lets the plugin know how to handle your device. Find your device `type` on the [Supported Device Type List](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Supported-Device-Types) page.
+* `type` (required) is a case-insensitive identifier that lets the plugin know how to handle your device. Find your device `type` on the [Supported Device Type List](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Supported-Device-Types) page.
 * `manufacturer` and `model` are anything you like; the purpose of them is to help you identify the device.
 * `id` (required) and `key` (required) are parameters for your device. If you don't have them, follow the steps found on the [Setup Instructions](https://github.com/iRayanKgan/homebridge-tuya/wiki/Setup-Instructions) page.
-* `ip` needs to be added **_only_** if you face discovery issues. See [Common Problems](https://github.com/hmenzagh/homebridge-tuya-platform-local/wiki/Common-Problems) for more details.   
+* `ip` needs to be added **_only_** if you face discovery issues. See [Common Problems](https://github.com/sapireli/homebridge-tuya-platform-local2/wiki/Common-Problems) for more details.   
 
 > To find out which `id` belongs to which device, open the Tuya Smart app and check the `Device Information` by tapping the configuration icon of your devices; it is almost always a tiny icon on the top-right.

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const SwitchAccessory = require('./lib/SwitchAccessory');
 const ValveAccessory = require('./lib/ValveAccessory');
 const OilDiffuserAccessory = require('./lib/OilDiffuserAccessory');
 
-const PLUGIN_NAME = 'homebridge-tuya-platform-local';
+const PLUGIN_NAME = 'homebridge-tuya-platform-local2';
 const PLATFORM_NAME = 'TuyaPlatformLocal';
 
 const CLASS_DEF = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "homebridge-tuya",
+  "name": "homebridge-tuya-platform-local2",
   "version": "3.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "homebridge-tuya",
+      "name": "homebridge-tuya-platform-local2",
       "version": "3.0.0-beta.3",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homebridge-tuya-platform-local",
+  "name": "homebridge-tuya-platform-local2",
   "displayName": "Homebridge Tuya Local",
   "version": "3.0.3",
   "description": "🏠 Unofficial Homebridge plugin enabling local control of Tuya smart devices",
@@ -14,14 +14,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hmenzagh/homebridge-tuya-platform-local.git"
+    "url": "git+https://github.com/sapireli/homebridge-tuya-platform-local2.git"
   },
   "author": "Rayan Khan & hmenzagh & Eliran Sapir",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/hmenzagh/homebridge-tuya-platform-local/issues"
+    "url": "https://github.com/sapireli/homebridge-tuya-platform-local2/issues"
   },
-  "homepage": "https://github.com/hmenzagh/homebridge-tuya-platform-local#readme",
+  "homepage": "https://github.com/sapireli/homebridge-tuya-platform-local2#readme",
   "dependencies": {
     "async": "^3.2.5",
     "commander": "^3.0.2",
@@ -38,10 +38,7 @@
     "tuya"
   ],
   "engines": {
-    codex/update-plugin-for-homebridge-2.0-compatibility
     "homebridge": ">=1.3.0",
-    "node": ">=14.17.0"
-    "homebridge": ">=0.4.0",
     "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- repair invalid JSON structure in `package.json`
- update repo links and package name to **homebridge-tuya-platform-local2**
- sync `package-lock.json`
- update plugin constant in `index.js`
- update documentation with new package name and links

## Testing
- `node -e "const pkg=require('./package.json');console.log('ok');"`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('package-lock.json','utf8')); console.log('ok');"`
- `npm pack --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_6875d468a178832fbada13984503150d